### PR TITLE
Remediation times and scalability fixes

### DIFF
--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/PackageAnalyzerPlugin.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/PackageAnalyzerPlugin.java
@@ -10,6 +10,7 @@ import nl.futureedge.sonar.plugin.packageanalyzer.rules.AbstractnessRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.AfferentCouplingRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.EfferentCouplingRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.InstabilityRule;
+import nl.futureedge.sonar.plugin.packageanalyzer.rules.UnstableDependencyRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.JavaRules;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.MissingPackageInfoRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.NumberOfClassesAndInterfacesRule;
@@ -35,6 +36,7 @@ public final class PackageAnalyzerPlugin implements Plugin {
 				AfferentCouplingRule.class,
 				EfferentCouplingRule.class,
 				InstabilityRule.class,
+				UnstableDependencyRule.class,
 				MissingPackageInfoRule.class,
 				NumberOfClassesAndInterfacesRule.class,
 				PackageDependencyCyclesRule.class);

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/PackageAnalyzerPlugin.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/PackageAnalyzerPlugin.java
@@ -8,6 +8,7 @@ import nl.futureedge.sonar.plugin.packageanalyzer.metrics.PackageAnalyzerCompute
 import nl.futureedge.sonar.plugin.packageanalyzer.metrics.PackageAnalyzerMetrics;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.AbstractnessRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.AfferentCouplingRule;
+import nl.futureedge.sonar.plugin.packageanalyzer.rules.DistanceFromMainSequenceRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.EfferentCouplingRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.InstabilityRule;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.UnstableDependencyRule;
@@ -34,6 +35,7 @@ public final class PackageAnalyzerPlugin implements Plugin {
 		// Rules
 		context.addExtensions(AbstractnessRule.class,
 				AfferentCouplingRule.class,
+				DistanceFromMainSequenceRule.class,
 				EfferentCouplingRule.class,
 				InstabilityRule.class,
 				UnstableDependencyRule.class,

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerComputer.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerComputer.java
@@ -5,8 +5,10 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.sonar.api.ce.measure.Component;
 import org.sonar.api.ce.measure.Measure;
 import org.sonar.api.ce.measure.MeasureComputer;
+import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -16,15 +18,23 @@ import org.sonar.api.utils.log.Loggers;
 public final class PackageAnalyzerComputer implements MeasureComputer {
 
 	private static final Logger LOGGER = Loggers.get(PackageAnalyzerComputer.class);
+	
+	private static final String METRIC_DIRECTORIES_NUMBER = CoreMetrics.DIRECTORIES_KEY;
 
 	@Override
 	public MeasureComputerDefinition define(final MeasureComputerDefinitionContext definitionContext) {
 		return definitionContext.newDefinitionBuilder()
 				.setInputMetrics(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIER.key(),
+						METRIC_DIRECTORIES_NUMBER,
+						PackageAnalyzerMetrics.AVERAGE_DEGREE.key(),
+						PackageAnalyzerMetrics.PACKAGE_DEGREE.key(),
+						PackageAnalyzerMetrics.VERTICE_DEGREE.key(),
 						PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS.key(),
 						PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES.key())
 				.setOutputMetrics(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS.key(),
-						PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES.key())
+						PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES.key(),
+						PackageAnalyzerMetrics.AVERAGE_DEGREE.key(),
+						PackageAnalyzerMetrics.PACKAGE_DEGREE.key())
 				.build();
 	}
 
@@ -32,6 +42,7 @@ public final class PackageAnalyzerComputer implements MeasureComputer {
 	public void compute(final MeasureComputerContext context) {
 		rollupIdentifiers(context);
 		countIdentifiers(context);
+		calcAverageDegree(context);
 	}
 
 	private void rollupIdentifiers(final MeasureComputerContext context) {
@@ -79,6 +90,38 @@ public final class PackageAnalyzerComputer implements MeasureComputer {
 
 		// Set measure
 		context.addMeasure(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES.key(), result);
+	}
+	
+	private void calcAverageDegree(final MeasureComputerContext context) {
+		int totalDegree = 0;
+		float result = 0.0f;
+		final Measure dir = context.getMeasure(METRIC_DIRECTORIES_NUMBER);
+		final int directories = dir != null ? dir.getIntValue() : 1;
+		
+		// Add child values, if any
+		for (final Measure childMeasure : context
+				.getChildrenMeasures(PackageAnalyzerMetrics.PACKAGE_DEGREE.key()))
+			totalDegree += childMeasure.getIntValue();
+			
+		final Measure self = context
+				.getMeasure(PackageAnalyzerMetrics.VERTICE_DEGREE.key());
+				
+		// Add self value if it does not have any children
+		if (self != null && totalDegree == 0)
+			totalDegree = self.getIntValue();
+		
+		context.addMeasure(PackageAnalyzerMetrics.PACKAGE_DEGREE.key(), totalDegree);
+		
+		// Calculate Average Degree
+		final Measure totalMeasure = context
+				.getMeasure(PackageAnalyzerMetrics.PACKAGE_DEGREE.key());
+				
+		if (context.getComponent().getType().equals(Component.Type.FILE) || 
+				context.getComponent().getType().equals(Component.Type.DIRECTORY))
+			result = totalMeasure.getIntValue();
+		else result = (float)2* totalMeasure.getIntValue() / directories;
+		
+		context.addMeasure(PackageAnalyzerMetrics.AVERAGE_DEGREE.key(), result);
 	}
 
 }

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerMetrics.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerMetrics.java
@@ -16,6 +16,15 @@ public final class PackageAnalyzerMetrics implements Metrics {
 	/** Metric for package dependency cycles. */
 	public static final Metric<Integer> PACKAGE_DEPENDENCY_CYCLES = new Metric.Builder("package-dependency-cycles",
 			"Package dependency cycles", Metric.ValueType.INT).setDomain(CoreMetrics.DOMAIN_COMPLEXITY).create();
+	/** Metric for Average Degree between all packages */
+	public static final Metric<Float> AVERAGE_DEGREE = new Metric.Builder("average-degree",
+			"Average Degree", Metric.ValueType.FLOAT).setDomain(CoreMetrics.DOMAIN_COMPLEXITY).create();
+	/** Metric for sum of identifiers degree value */
+	public static final Metric<Integer> PACKAGE_DEGREE = new Metric.Builder("package-degree",
+			"Package Degree", Metric.ValueType.INT).setDomain(CoreMetrics.DOMAIN_COMPLEXITY).setHidden(true).create();
+	/** Metric for identifier degree value */
+	public static final Metric<Integer> VERTICE_DEGREE = new Metric.Builder("vertice-degree",
+			"Vertice Degree", Metric.ValueType.INT).setDomain(CoreMetrics.DOMAIN_COMPLEXITY).setHidden(true).create();
 	/** Metric for package dependency cycle (identifier). */
 	public static final Metric<String> PACKAGE_DEPENDENCY_CYCLES_IDENTIFIER = new Metric.Builder(
 			"package-dependency-cycles-identifier", "Package dependency cycles (identifier)", Metric.ValueType.STRING)
@@ -28,7 +37,7 @@ public final class PackageAnalyzerMetrics implements Metrics {
 	@Override
 	@SuppressWarnings("rawtypes")
 	public List<Metric> getMetrics() {
-		return asList(PACKAGE_DEPENDENCY_CYCLES, PACKAGE_DEPENDENCY_CYCLES_IDENTIFIER,
-				PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS);
+		return asList(PACKAGE_DEPENDENCY_CYCLES, AVERAGE_DEGREE, PACKAGE_DEGREE, VERTICE_DEGREE,
+		PACKAGE_DEPENDENCY_CYCLES_IDENTIFIER, PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS);
 	}
 }

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRule.java
@@ -43,18 +43,22 @@ public final class AbstractnessRule extends AbstractPackageAnalyzerRule implemen
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule abstractnessRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setName("Abstractness").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setGapDescription("for each class inside the package.").setName("Abstractness").setHtmlDescription(
 						"The ratio of the number of abstract classes (and interfaces) in the analyzed package compared to the total number of classes in the analyzed package.<br/>"
 								+ "The range for this metric is 0% to 100%, with A=0% indicating a completely concrete package and A=100% indicating a completely abstract package.");
-		//Remediation times
-		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-				abstractnessRule.setDebtRemediationFunction(abstractnessRule.debtRemediationFunctions().constantPerIssue("15min"));
-			else abstractnessRule.setDebtRemediationFunction(abstractnessRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
-			abstractnessRule.setGapDescription("for each class inside the package.");
 		//Maximum abstractness allowed in a package	
 		abstractnessRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
-				.setDescription("Maximum abstractness of a package allowed").setType(RuleParamType.INTEGER)
-				.setDefaultValue("75");
+			.setDescription("Maximum abstractness of a package allowed").setType(RuleParamType.INTEGER)
+			.setDefaultValue("75");
+		
+		defineRemediationTimes(abstractnessRule);
+	}
+	
+	@Override
+	public void defineRemediationTimes(final NewRule rule) {
+		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
+		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
 	}
 
 	@Override

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRule.java
@@ -14,6 +14,7 @@ import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
@@ -45,6 +46,12 @@ public final class AbstractnessRule extends AbstractPackageAnalyzerRule implemen
 				.setSeverity(Severity.MAJOR).setName("Abstractness").setHtmlDescription(
 						"The ratio of the number of abstract classes (and interfaces) in the analyzed package compared to the total number of classes in the analyzed package.<br/>"
 								+ "The range for this metric is 0% to 100%, with A=0% indicating a completely concrete package and A=100% indicating a completely abstract package.");
+		//Remediation times
+		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+				abstractnessRule.setDebtRemediationFunction(abstractnessRule.debtRemediationFunctions().constantPerIssue("15min"));
+			else abstractnessRule.setDebtRemediationFunction(abstractnessRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
+			abstractnessRule.setGapDescription("for each class inside the package.");
+		//Maximum abstractness allowed in a package	
 		abstractnessRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
 				.setDescription("Maximum abstractness of a package allowed").setType(RuleParamType.INTEGER)
 				.setDefaultValue("75");

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
@@ -15,6 +15,7 @@ import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
@@ -42,10 +43,16 @@ public final class AfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 	@Override
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
-		final NewRule afferentCouplingsRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
+		final NewRule afferentCouplingRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
 				.setSeverity(Severity.MAJOR).setName("Afferent Coupling").setHtmlDescription(
 						"The number of other packages that depend upon classes within the package is an indicator of the package's responsibility.");
-		afferentCouplingsRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
+		//Remediation times
+		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+				afferentCouplingRule.setDebtRemediationFunction(afferentCouplingRule.debtRemediationFunctions().constantPerIssue("15min"));
+			else afferentCouplingRule.setDebtRemediationFunction(afferentCouplingRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
+			afferentCouplingRule.setGapDescription("for each class inside the package.");
+		//The number of classes in other packages that depend upon classes within the package
+		afferentCouplingRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
 				.setDescription("Maximum number of other packages allowed to depend upon classes within the package")
 				.setType(RuleParamType.INTEGER).setDefaultValue("25");
 	}

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
@@ -30,21 +30,18 @@ public final class AfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 	private static final String RULE_KEY = "afferent-coupling";
 	private static final String PARAM_MAXIMUM = "maximum";
 
-	private final Settings settings;
-
 	/**
 	 * Afferent coupling rule.
 	 */
 	public AfferentCouplingRule(final Settings settings) {
-		super(RULE_KEY);
-		this.settings = settings;
+		super(RULE_KEY, settings);
 	}
 
 	@Override
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule afferentCouplingRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setGapDescription("for each class inside the package.").setName("Afferent Coupling").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setGapDescription("for each related class inside the package.").setName("Afferent Coupling").setHtmlDescription(
 						"The number of other packages that depend upon classes within the package is an indicator of the package's responsibility.");
 		//The number of classes in other packages that depend upon classes within the package
 		afferentCouplingRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
@@ -52,13 +49,6 @@ public final class AfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 				.setType(RuleParamType.INTEGER).setDefaultValue("25");
 		
 		defineRemediationTimes(afferentCouplingRule);
-	}
-
-	@Override
-	public void defineRemediationTimes(final NewRule rule) {
-		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
-		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
 	}
 	
 	@Override
@@ -73,7 +63,7 @@ public final class AfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 			if (afferentCoupling > maximum) {
 				final Set<Class<Location>> classes = selectClassesWithAfferentUsage(packageToCheck.getClasses());
 
-				registerIssue(context, settings, rule, packageToCheck, classes,
+				registerIssue(context, getSettings(), rule, packageToCheck, classes,
 						"Reduce number of packages that use this package (allowed: " + maximum + ", actual: "
 								+ afferentCoupling + ")");
 			}

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
@@ -87,7 +87,7 @@ public final class AfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 	 *            package classes
 	 * @return classes that have afferent usages
 	 */
-	private static Set<Class<Location>> selectClassesWithAfferentUsage(
+	protected static Set<Class<Location>> selectClassesWithAfferentUsage(
 			final SortedSet<Class<Location>> packageClasses) {
 		final Set<Class<Location>> result = new HashSet<>();
 

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AfferentCouplingRule.java
@@ -44,19 +44,23 @@ public final class AfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule afferentCouplingRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setName("Afferent Coupling").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setGapDescription("for each class inside the package.").setName("Afferent Coupling").setHtmlDescription(
 						"The number of other packages that depend upon classes within the package is an indicator of the package's responsibility.");
-		//Remediation times
-		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-				afferentCouplingRule.setDebtRemediationFunction(afferentCouplingRule.debtRemediationFunctions().constantPerIssue("15min"));
-			else afferentCouplingRule.setDebtRemediationFunction(afferentCouplingRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
-			afferentCouplingRule.setGapDescription("for each class inside the package.");
 		//The number of classes in other packages that depend upon classes within the package
 		afferentCouplingRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
 				.setDescription("Maximum number of other packages allowed to depend upon classes within the package")
 				.setType(RuleParamType.INTEGER).setDefaultValue("25");
+		
+		defineRemediationTimes(afferentCouplingRule);
 	}
 
+	@Override
+	public void defineRemediationTimes(final NewRule rule) {
+		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
+		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
+	}
+	
 	@Override
 	public void scanModel(final SensorContext context, final ActiveRule rule, final Model<Location> model) {
 		final Integer maximum = Integer.valueOf(rule.param(PARAM_MAXIMUM));

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/BaseRules.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/BaseRules.java
@@ -46,7 +46,6 @@ public class BaseRules implements RulesDefinition {
 	@Override
 	public final void define(final Context context) {
 		final NewRepository repository = context.createRepository(getRepositoryKey(language), language).setName(NAME);
-
 		for (final PackageAnalyzerRule rule : rules) {
 			if (rule.supportsLanguage(language)) {
 				rule.define(repository);

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/DistanceFromMainSequenceRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/DistanceFromMainSequenceRule.java
@@ -1,0 +1,73 @@
+package nl.futureedge.sonar.plugin.packageanalyzer.rules;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.config.Settings;
+import org.sonar.api.rule.Severity;
+import org.sonar.api.rules.RuleType;
+import org.sonar.api.server.rule.RuleParamType;
+import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
+
+public class DistanceFromMainSequenceRule extends AbstractPackageAnalyzerRule implements PackageAnalyzerRule {
+	
+	private static final Logger LOGGER = Loggers.get(UnstableDependencyRule.class);
+
+	private static final String RULE_KEY = "distanceFromMainSequence";
+	private static final String PARAM_MAXIMUM = "maximum";
+	
+	/**
+	 * Distance from main sequence rule.
+	 */
+	public DistanceFromMainSequenceRule(final Settings settings) {
+		super(RULE_KEY, settings);
+	}
+	
+	@Override
+	public void define(final NewRepository repository) {
+		LOGGER.debug("Defining rule in repository {}", repository.key());
+		final NewRule DistanceFromMainSequenceRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
+				.setSeverity(Severity.MAJOR).setName("Distance From Main Sequence").setGapDescription("for each related class inside the package.")
+				.setHtmlDescription("This metric has the primary rationale where abstractness and stability of packages should be closely connected."
+				+ "The Perpendicular Distance of a Package from the Idealized Line D = A + I - 1, has the ideal value of D = 0. <br/>"
+				+ "Instability is associated with a package that depends on outter ones, and therefore any changes on these may cause changes on said package. <br/>"
+				+ "Thus, this rule suggests that the more abstract a package is, the more stable it should be, and vice versa.");
+		//Maximum unstableDependenciesRatio allowed in a package	
+		DistanceFromMainSequenceRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
+				.setDescription("Maximum Distance From Main Sequence(%) of a package allowed").setType(RuleParamType.INTEGER)
+				.setDefaultValue("70");
+				
+		defineRemediationTimes(DistanceFromMainSequenceRule);
+	}
+	
+	@Override
+	public void scanModel(final SensorContext context, final ActiveRule rule, final Model<Location> model) {
+		final Integer maximum = Integer.valueOf(rule.param(PARAM_MAXIMUM));
+
+		for (final Package<Location> packageToCheck : model.getPackages()) {
+			final int instability = InstabilityRule.calcInstability(packageToCheck);
+			final int abstractness = AbstractnessRule.calcAbstractness(packageToCheck);
+			final int distance = Math.abs(abstractness + instability - 100);
+
+			if (distance > maximum) {
+				final Set<Class<Location>> classes = packageToCheck.getClasses().stream().filter(Class::isAbstract)
+						.collect(Collectors.toSet());
+				classes.addAll(EfferentCouplingRule.selectClassesWithEfferentUsage(packageToCheck.getClasses()));
+				
+				registerIssue(context, getSettings(), rule, packageToCheck, classes, 
+						"Distance from main sequence value is too high (" + distance + "%)" + ", consider refactoring the package in order to lower it"
+						+ " (values for instability: " + instability + "%" + ", abstractness: " + abstractness + "%).");
+			}
+		}
+	}
+
+}

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/EfferentCouplingRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/EfferentCouplingRule.java
@@ -15,11 +15,10 @@ import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
-import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
+import nl.futureedge.sonar.plugin.packageanalyzer.metrics.PackageAnalyzerMetrics;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
-
 /**
  * Efferent coupling rule.
  */
@@ -30,21 +29,18 @@ public final class EfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 	private static final String RULE_KEY = "efferent-coupling";
 	private static final String PARAM_MAXIMUM = "maximum";
 
-	private final Settings settings;
-
 	/**
 	 * Efferent coupling rule.
 	 */
 	public EfferentCouplingRule(final Settings settings) {
-		super(RULE_KEY);
-		this.settings = settings;
+		super(RULE_KEY, settings);
 	}
 
 	@Override
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule efferentCouplingRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setGapDescription("for each class inside the package.").setName("Efferent Coupling").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setGapDescription("for each related class inside the package.").setName("Efferent Coupling").setHtmlDescription(
 						"The number of other packages that the classes in the package depend upon is an indicator of the package's independence.");
 		//The number of classes in other packages that the classes in a package depend upon
 		efferentCouplingRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
@@ -53,13 +49,6 @@ public final class EfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 		
 		defineRemediationTimes(efferentCouplingRule);
 	}
-
-	@Override
-	public void defineRemediationTimes(final NewRule rule) {
-		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
-		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
-	}
 	
 	@Override
 	public void scanModel(final SensorContext context, final ActiveRule rule, final Model<Location> model) {
@@ -67,13 +56,17 @@ public final class EfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 
 		for (final Package<Location> packageToCheck : model.getPackages()) {
 			final int efferentCoupling = packageToCheck.getPackageUsages().size();
+			
+			// Number of edges (connections) used to calculate Average Degree of the graph
+			final int numEdges = packageToCheck.getPackageUsages().size();
+			registerMeasure(context, PackageAnalyzerMetrics.VERTICE_DEGREE, packageToCheck, numEdges);
 
 			LOGGER.debug("Package {}: efferent={}", packageToCheck.getName(), efferentCoupling);
 
 			if (efferentCoupling > maximum) {
 				final Set<Class<Location>> classes = selectClassesWithEfferentUsage(packageToCheck.getClasses());
 
-				registerIssue(context, settings, rule, packageToCheck, classes,
+				registerIssue(context, getSettings(), rule, packageToCheck, classes,
 						"Reduce number of packages used by this package (allowed: " + maximum + ", actual: "
 								+ efferentCoupling + ")");
 			}

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/EfferentCouplingRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/EfferentCouplingRule.java
@@ -44,20 +44,23 @@ public final class EfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule efferentCouplingRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setName("Efferent Coupling").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setGapDescription("for each class inside the package.").setName("Efferent Coupling").setHtmlDescription(
 						"The number of other packages that the classes in the package depend upon is an indicator of the package's independence.");
-		//Remediation times
-		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-				efferentCouplingRule.setDebtRemediationFunction(efferentCouplingRule.debtRemediationFunctions().constantPerIssue("15min"));
-			else efferentCouplingRule.setDebtRemediationFunction(efferentCouplingRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
-			efferentCouplingRule.setGapDescription("for each class inside the package.");
 		//The number of classes in other packages that the classes in a package depend upon
 		efferentCouplingRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
-				.setDescription(
-						"Maximum number of other packages that the classes in the package are allowed to depend upon")
+				.setDescription("Maximum number of other packages that the classes in the package are allowed to depend upon")
 				.setType(RuleParamType.INTEGER).setDefaultValue("25");
+		
+		defineRemediationTimes(efferentCouplingRule);
 	}
 
+	@Override
+	public void defineRemediationTimes(final NewRule rule) {
+		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
+		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
+	}
+	
 	@Override
 	public void scanModel(final SensorContext context, final ActiveRule rule, final Model<Location> model) {
 		final Integer maximum = Integer.valueOf(rule.param(PARAM_MAXIMUM));

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/EfferentCouplingRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/EfferentCouplingRule.java
@@ -15,6 +15,7 @@ import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
@@ -45,6 +46,12 @@ public final class EfferentCouplingRule extends AbstractPackageAnalyzerRule impl
 		final NewRule efferentCouplingRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
 				.setSeverity(Severity.MAJOR).setName("Efferent Coupling").setHtmlDescription(
 						"The number of other packages that the classes in the package depend upon is an indicator of the package's independence.");
+		//Remediation times
+		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+				efferentCouplingRule.setDebtRemediationFunction(efferentCouplingRule.debtRemediationFunctions().constantPerIssue("15min"));
+			else efferentCouplingRule.setDebtRemediationFunction(efferentCouplingRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
+			efferentCouplingRule.setGapDescription("for each class inside the package.");
+		//The number of classes in other packages that the classes in a package depend upon
 		efferentCouplingRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
 				.setDescription(
 						"Maximum number of other packages that the classes in the package are allowed to depend upon")

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
@@ -13,6 +13,7 @@ import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
@@ -44,6 +45,12 @@ public final class InstabilityRule extends AbstractPackageAnalyzerRule implement
 				.setSeverity(Severity.MAJOR).setName("Instability").setHtmlDescription(
 						"The ratio of efferent coupling (Ce) to total coupling (Ce + Ca) such that I = Ce / (Ce + Ca). This metric is an indicator of the package's resilience to change.<br/>"
 								+ "The range for this metric is 0 to 100%, with I=0% indicating a completely stable package and I=100% indicating a completely instable package.");
+		//Remediation times
+		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+				instabilityRule.setDebtRemediationFunction(instabilityRule.debtRemediationFunctions().constantPerIssue("15min"));
+			else instabilityRule.setDebtRemediationFunction(instabilityRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
+			instabilityRule.setGapDescription("for each class inside the package.");
+		//Maximum instability allowed in a package	
 		instabilityRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
 				.setDescription("Maximum instability (%) of a package allowed").setType(RuleParamType.INTEGER)
 				.setDefaultValue("75");

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
@@ -42,18 +42,22 @@ public final class InstabilityRule extends AbstractPackageAnalyzerRule implement
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule instabilityRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setName("Instability").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setName("Instability").setGapDescription("for each class inside the package.").setHtmlDescription(
 						"The ratio of efferent coupling (Ce) to total coupling (Ce + Ca) such that I = Ce / (Ce + Ca). This metric is an indicator of the package's resilience to change.<br/>"
 								+ "The range for this metric is 0 to 100%, with I=0% indicating a completely stable package and I=100% indicating a completely instable package.");
-		//Remediation times
-		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-				instabilityRule.setDebtRemediationFunction(instabilityRule.debtRemediationFunctions().constantPerIssue("15min"));
-			else instabilityRule.setDebtRemediationFunction(instabilityRule.debtRemediationFunctions().linearWithOffset("7min", "1h"));
-			instabilityRule.setGapDescription("for each class inside the package.");
 		//Maximum instability allowed in a package	
 		instabilityRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
-				.setDescription("Maximum instability (%) of a package allowed").setType(RuleParamType.INTEGER)
-				.setDefaultValue("75");
+			.setDescription("Maximum instability (%) of a package allowed").setType(RuleParamType.INTEGER)
+			.setDefaultValue("75");
+		
+		defineRemediationTimes(instabilityRule);
+	}
+	
+	@Override
+	public void defineRemediationTimes(final NewRule rule) {
+		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
+		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
 	}
 
 	@Override

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
@@ -65,13 +65,7 @@ public final class InstabilityRule extends AbstractPackageAnalyzerRule implement
 		final Integer maximum = Integer.valueOf(rule.param(PARAM_MAXIMUM));
 
 		for (final Package<Location> packageToCheck : model.getPackages()) {
-			final int afferentCoupling = packageToCheck.getUsedByPackages().size();
-			final int efferentCoupling = packageToCheck.getPackageUsages().size();
-			final int totalCoupling = efferentCoupling + afferentCoupling;
-			final int instability = totalCoupling == 0 ? 0 : (efferentCoupling * 100) / totalCoupling;
-
-			LOGGER.debug("Package {}: efferent={}, total={}, instability={}", packageToCheck.getName(),
-					efferentCoupling, totalCoupling, instability);
+			final int instability = calcInstability(packageToCheck);
 
 			if (instability > maximum) {
 				final Set<Class<Location>> classes = EfferentCouplingRule
@@ -82,5 +76,16 @@ public final class InstabilityRule extends AbstractPackageAnalyzerRule implement
 								+ "%, actual: " + instability + "%)");
 			}
 		}
+	}
+	
+	protected static int calcInstability(final Package<Location> packageToCheck) {
+		final int afferentCoupling = packageToCheck.getUsedByPackages().size();
+		final int efferentCoupling = packageToCheck.getPackageUsages().size();
+		final int totalCoupling = efferentCoupling + afferentCoupling;
+		final int instability = totalCoupling == 0 ? 0 : (efferentCoupling * 100) / totalCoupling;
+		LOGGER.debug("Package {}: efferent={}, total={}, instability={}", packageToCheck.getName(),
+					efferentCoupling, totalCoupling, instability);
+		
+		return instability;
 	}
 }

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/InstabilityRule.java
@@ -28,21 +28,18 @@ public final class InstabilityRule extends AbstractPackageAnalyzerRule implement
 	private static final String RULE_KEY = "instability";
 	private static final String PARAM_MAXIMUM = "maximum";
 
-	private final Settings settings;
-
 	/**
 	 * Instability rule.
 	 */
 	public InstabilityRule(final Settings settings) {
-		super(RULE_KEY);
-		this.settings = settings;
+		super(RULE_KEY, settings);
 	}
 
 	@Override
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule instabilityRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setName("Instability").setGapDescription("for each class inside the package.").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setName("Instability").setGapDescription("for each related class inside the package.").setHtmlDescription(
 						"The ratio of efferent coupling (Ce) to total coupling (Ce + Ca) such that I = Ce / (Ce + Ca). This metric is an indicator of the package's resilience to change.<br/>"
 								+ "The range for this metric is 0 to 100%, with I=0% indicating a completely stable package and I=100% indicating a completely instable package.");
 		//Maximum instability allowed in a package	
@@ -51,13 +48,6 @@ public final class InstabilityRule extends AbstractPackageAnalyzerRule implement
 			.setDefaultValue("75");
 		
 		defineRemediationTimes(instabilityRule);
-	}
-	
-	@Override
-	public void defineRemediationTimes(final NewRule rule) {
-		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
-		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
 	}
 
 	@Override
@@ -71,7 +61,7 @@ public final class InstabilityRule extends AbstractPackageAnalyzerRule implement
 				final Set<Class<Location>> classes = EfferentCouplingRule
 						.selectClassesWithEfferentUsage(packageToCheck.getClasses());
 
-				registerIssue(context, settings, rule, packageToCheck, classes,
+				registerIssue(context, getSettings(), rule, packageToCheck, classes,
 						"Reduce number of packages used by this package to lower instability (allowed: " + maximum
 								+ "%, actual: " + instability + "%)");
 			}

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/MissingPackageInfoRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/MissingPackageInfoRule.java
@@ -5,6 +5,7 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.rule.Severity;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -34,6 +35,11 @@ public final class MissingPackageInfoRule extends AbstractPackageAnalyzerRule im
 		repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL).setSeverity(Severity.BLOCKER)
 				.setName("Missing package-info.java").setHtmlDescription(
 						"When a package-info.java file is missing, no issues can be reported on the package level.");
+	}
+	
+	@Override
+	public void defineRemediationTimes(NewRule rule) {
+		// Unused
 	}
 
 	@Override

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
@@ -11,6 +11,7 @@ import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
 
@@ -40,6 +41,12 @@ public final class NumberOfClassesAndInterfacesRule extends AbstractPackageAnaly
 		final NewRule numberOfClassesAndInterfacesRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
 				.setSeverity(Severity.MAJOR).setName("Number of Classes and Interfaces").setHtmlDescription(
 						"The number of concrete and abstract classes (and interfaces) in the package is an indicator of the extensibility of the package.");
+		//Remediation times
+		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+				numberOfClassesAndInterfacesRule.setDebtRemediationFunction(numberOfClassesAndInterfacesRule.debtRemediationFunctions().constantPerIssue("3min"));
+			else numberOfClassesAndInterfacesRule.setDebtRemediationFunction(numberOfClassesAndInterfacesRule.debtRemediationFunctions().constantPerIssue("3h"));
+			numberOfClassesAndInterfacesRule.setGapDescription("for each class inside the package.");
+		//Maximum number of classes and interfaces in a package
 		numberOfClassesAndInterfacesRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
 				.setDescription("Maximum number of classes and interfaces allowed in the package")
 				.setType(RuleParamType.INTEGER).setDefaultValue("50");

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
@@ -44,7 +44,7 @@ public final class NumberOfClassesAndInterfacesRule extends AbstractPackageAnaly
 		//Remediation times
 		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
 				numberOfClassesAndInterfacesRule.setDebtRemediationFunction(numberOfClassesAndInterfacesRule.debtRemediationFunctions().constantPerIssue("3min"));
-			else numberOfClassesAndInterfacesRule.setDebtRemediationFunction(numberOfClassesAndInterfacesRule.debtRemediationFunctions().constantPerIssue("3h"));
+			else numberOfClassesAndInterfacesRule.setDebtRemediationFunction(numberOfClassesAndInterfacesRule.debtRemediationFunctions().linearWithOffset("2min", "1h"));
 			numberOfClassesAndInterfacesRule.setGapDescription("for each class inside the package.");
 		//Maximum number of classes and interfaces in a package
 		numberOfClassesAndInterfacesRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
@@ -39,17 +39,21 @@ public final class NumberOfClassesAndInterfacesRule extends AbstractPackageAnaly
 	public void define(final NewRepository repository) {
 		LOGGER.debug("Defining rule in repostiory {}", repository.key());
 		final NewRule numberOfClassesAndInterfacesRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
-				.setSeverity(Severity.MAJOR).setName("Number of Classes and Interfaces").setHtmlDescription(
+				.setSeverity(Severity.MAJOR).setGapDescription("for each class inside the package.").setName("Number of Classes and Interfaces").setHtmlDescription(
 						"The number of concrete and abstract classes (and interfaces) in the package is an indicator of the extensibility of the package.");
-		//Remediation times
-		if(PackageAnalyzerProperties.shouldRegisterOnClasses(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
-				numberOfClassesAndInterfacesRule.setDebtRemediationFunction(numberOfClassesAndInterfacesRule.debtRemediationFunctions().constantPerIssue("3min"));
-			else numberOfClassesAndInterfacesRule.setDebtRemediationFunction(numberOfClassesAndInterfacesRule.debtRemediationFunctions().linearWithOffset("2min", "1h"));
-			numberOfClassesAndInterfacesRule.setGapDescription("for each class inside the package.");
 		//Maximum number of classes and interfaces in a package
 		numberOfClassesAndInterfacesRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
 				.setDescription("Maximum number of classes and interfaces allowed in the package")
 				.setType(RuleParamType.INTEGER).setDefaultValue("50");
+		
+		defineRemediationTimes(numberOfClassesAndInterfacesRule);
+	}
+	
+	@Override
+	public void defineRemediationTimes(final NewRule rule) {
+		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("3min", "0min"));
+		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("2min", "58min"));
 	}
 
 	@Override

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/NumberOfClassesAndInterfacesRule.java
@@ -25,14 +25,11 @@ public final class NumberOfClassesAndInterfacesRule extends AbstractPackageAnaly
 	private static final String RULE_KEY = "number-of-classes-and-interfaces";
 	private static final String PARAM_MAXIMUM = "maximum";
 
-	private final Settings settings;
-
 	/**
 	 * Constructor.
 	 */
 	public NumberOfClassesAndInterfacesRule(final Settings settings) {
-		super(RULE_KEY);
-		this.settings = settings;
+		super(RULE_KEY, settings);
 	}
 
 	@Override
@@ -51,7 +48,7 @@ public final class NumberOfClassesAndInterfacesRule extends AbstractPackageAnaly
 	
 	@Override
 	public void defineRemediationTimes(final NewRule rule) {
-		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(getSettings()) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(getSettings()))
 			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("3min", "0min"));
 		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("2min", "58min"));
 	}
@@ -66,7 +63,7 @@ public final class NumberOfClassesAndInterfacesRule extends AbstractPackageAnaly
 			LOGGER.debug("Package {}: total={}", packageToCheck.getName(), classcount);
 
 			if (classcount > maximum) {
-				registerIssue(context, settings, rule, packageToCheck, packageToCheck.getClasses(),
+				registerIssue(context, getSettings(), rule, packageToCheck, packageToCheck.getClasses(),
 						"Reduce number of classes in package (allowed: " + maximum + ", actual: " + classcount + ")");
 			}
 		}

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/PackageAnalyzerRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/PackageAnalyzerRule.java
@@ -5,6 +5,7 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.server.ServerSide;
 import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
 import org.sonar.api.server.ws.Definable;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
@@ -30,6 +31,13 @@ public interface PackageAnalyzerRule extends Definable<RulesDefinition.NewReposi
 	 */
 	void scanModel(SensorContext context, String language, Model<Location> model);
 
+	/**
+	 * Defining remediation times for the rule.
+	 * @param rule
+	 * 			Rule to be defined
+	 */
+	void defineRemediationTimes(final NewRule rule);
+	
 	/**
 	 * Does this rule support the given language?
 	 * 

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/PackageDependencyCyclesRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/PackageDependencyCyclesRule.java
@@ -36,14 +36,11 @@ public final class PackageDependencyCyclesRule extends AbstractPackageAnalyzerRu
 
 	private static final String RULE_KEY = "package-cycle";
 
-	private final Settings settings;
-
 	/**
 	 * Constructor.
 	 */
 	public PackageDependencyCyclesRule(final Settings settings) {
-		super(RULE_KEY);
-		this.settings = settings;
+		super(RULE_KEY, settings);
 	}
 
 	@Override
@@ -56,7 +53,7 @@ public final class PackageDependencyCyclesRule extends AbstractPackageAnalyzerRu
 	
 	@Override
 	public void defineRemediationTimes(final NewRule rule) {		
-		if(PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && !PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+		if(PackageAnalyzerProperties.shouldRegisterOnPackage(getSettings()) && !PackageAnalyzerProperties.shouldRegisterOnAllClasses(getSettings()))
 			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("40min", "10min"));
 		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("15min", "5min"));
 	}
@@ -66,6 +63,7 @@ public final class PackageDependencyCyclesRule extends AbstractPackageAnalyzerRu
 		// Analyze
 		final Analyzer<Location> analyzer = new Analyzer<>();
 		final List<PackageCycle<Location>> packageCycles = analyzer.findPackageCycles(model);
+		final Settings settings = getSettings();
 		LOGGER.debug("Package cycles: {}", packageCycles.size());
 
 		int packageCycleIdentifier = 0;

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/UnstableDependencyRule.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/UnstableDependencyRule.java
@@ -1,0 +1,93 @@
+package nl.futureedge.sonar.plugin.packageanalyzer.rules;
+
+import java.util.Set;
+
+import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.config.Settings;
+import org.sonar.api.rule.Severity;
+import org.sonar.api.rules.RuleType;
+import org.sonar.api.server.rule.RuleParamType;
+import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
+
+/**
+ * Unstable Dependency.
+ */
+public final class UnstableDependencyRule extends AbstractPackageAnalyzerRule implements PackageAnalyzerRule {
+
+	private static final Logger LOGGER = Loggers.get(UnstableDependencyRule.class);
+
+	private static final String RULE_KEY = "UnstableDependency";
+	private static final String PARAM_MAXIMUM = "maximum";
+
+	private final Settings settings;
+
+	/**
+	 * Unstable Dependency rule.
+	 */
+	public UnstableDependencyRule(final Settings settings) {
+		super(RULE_KEY);
+		this.settings = settings;
+	}
+
+	@Override
+	public void define(final NewRepository repository) {
+		LOGGER.debug("Defining rule in repository {}", repository.key());
+		final NewRule unstableDependencyRule = repository.createRule(RULE_KEY).setType(RuleType.CODE_SMELL)
+				.setSeverity(Severity.MAJOR).setName("Unstable Dependency").setGapDescription("for each class inside the package.")
+				.setHtmlDescription("Stable-dependencies principle states that if a package "
+				+ "references another that is more likely to change and therefore less stable, there is a great chance that "
+				+ "this package also needs to be updated. This rule describes a package that depends on other packages that are less stable than itself.");
+		//Maximum unstableDependenciesRatio allowed in a package	
+		unstableDependencyRule.createParam(PARAM_MAXIMUM).setName(PARAM_MAXIMUM)
+				.setDescription("Maximum ratio(%) between unstable dependencies and total dependencies to other packages allowed").setType(RuleParamType.INTEGER)
+				.setDefaultValue("30");
+				
+		defineRemediationTimes(unstableDependencyRule);
+	}
+	
+	@Override
+	public void defineRemediationTimes(final NewRule rule) {
+		if(!PackageAnalyzerProperties.shouldRegisterOnPackage(settings) && PackageAnalyzerProperties.shouldRegisterOnAllClasses(settings))
+			rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("12min", "0min"));
+		else rule.setDebtRemediationFunction(rule.debtRemediationFunctions().linearWithOffset("5min", "45min"));
+	}
+
+	@Override
+	public void scanModel(final SensorContext context, final ActiveRule rule, final Model<Location> model) {
+		final Integer maximum = Integer.valueOf(rule.param(PARAM_MAXIMUM));
+
+		for (final Package<Location> packageToCheck : model.getPackages()) {
+			final Set<Package<Location>> afferentPackages = packageToCheck.getUsedByPackages();
+			final int afferentCoupling = afferentPackages.size();
+			final int efferentCoupling = packageToCheck.getPackageUsages().size();
+			final int totalCoupling = efferentCoupling + afferentCoupling;
+			final int instability = totalCoupling == 0 ? 0 : (efferentCoupling * 100) / totalCoupling;
+			
+			int unstableDependencies = 0;
+			for (final Package<Location> packageToCompare : afferentPackages) {
+				final int inst = InstabilityRule.calcInstability(packageToCompare);
+				if (instability < inst) 
+					unstableDependencies++;
+			}
+			
+			final int unstableDependenciesRatio = totalCoupling == 0 ? 0 : (unstableDependencies * 100) / totalCoupling;
+			if (unstableDependenciesRatio > maximum) {
+				LOGGER.debug("Package with unstableDependencies {}: totalCoupling={}, unstableDependencies={}, unstableDependenciesRatio={}%", 
+					packageToCheck.getName(), totalCoupling, unstableDependencies, unstableDependenciesRatio);
+				final Set<Class<Location>> classes = AfferentCouplingRule.selectClassesWithAfferentUsage(packageToCheck.getClasses());
+				registerIssue(context, settings, rule, packageToCheck, classes, 
+					"The ratio between unstable dependencies and the total number of dependencies is too high (allowed: " +
+					maximum + "%, actual: " + unstableDependenciesRatio + "%)");
+			}
+		}
+	}
+}

--- a/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/settings/PackageAnalyzerProperties.java
+++ b/plugin/src/main/java/nl/futureedge/sonar/plugin/packageanalyzer/settings/PackageAnalyzerProperties.java
@@ -75,6 +75,18 @@ public final class PackageAnalyzerProperties {
 	}
 
 	/**
+	 * Should issues be registered using fallback?
+	 *
+	 * @param settings
+	 *            settings
+	 * @return true, if issues should be registered using fallback
+	 */
+	 public static boolean shouldRegisterOnFallback(final Settings settings) {
+		final String issueMode = settings.getString(ISSUE_MODE_KEY);
+		return ISSUE_MODE_FALLBACK.equals(issueMode);
+	 }
+	 
+	/**
 	 * Should issues be registered on packages?
 	 *
 	 * @param settings

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerComputerTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerComputerTest.java
@@ -9,11 +9,14 @@ import org.sonar.api.ce.measure.test.TestComponent;
 import org.sonar.api.ce.measure.test.TestMeasureComputerContext;
 import org.sonar.api.ce.measure.test.TestMeasureComputerDefinitionContext;
 import org.sonar.api.ce.measure.test.TestSettings;
+import org.sonar.api.measures.CoreMetrics;
 
 public class PackageAnalyzerComputerTest {
 
 	private final PackageAnalyzerComputer subject = new PackageAnalyzerComputer();
 
+	private static final String METRIC_DIRECTORIES_NUMBER = CoreMetrics.DIRECTORIES_KEY;
+	
 	private TestMeasureComputerDefinitionContext definitionContext;
 	private MeasureComputerDefinition definition;
 
@@ -28,9 +31,11 @@ public class PackageAnalyzerComputerTest {
 		definition = subject.define(definitionContext);
 
 		settings = new TestSettings();
-		component = new TestComponent("test", Type.DIRECTORY, null);
-
-		context = new TestMeasureComputerContext(component, settings, definition);
+		component = new TestComponent("test", Type.PROJECT, null);
+		
+		context = new TestMeasureComputerContext(component, settings, definition);	
+		
+		context.addInputMeasure(METRIC_DIRECTORIES_NUMBER, 7);
 	}
 
 	@Test
@@ -39,12 +44,13 @@ public class PackageAnalyzerComputerTest {
 		final MeasureComputerDefinition definition = subject.define(definitionContext);
 
 		Assert.assertNotNull(definition);
-		Assert.assertEquals(3, definition.getInputMetrics().size());
+		Assert.assertEquals(7, definition.getInputMetrics().size());
 		Assert.assertTrue(definition.getInputMetrics().contains(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIER.key()));
-		Assert.assertTrue(definition.getOutputMetrics().contains(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS.key()));
+		Assert.assertTrue(definition.getInputMetrics().contains(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS.key()));
 		Assert.assertTrue(definition.getInputMetrics().contains(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES.key()));
+		Assert.assertTrue(definition.getInputMetrics().contains(METRIC_DIRECTORIES_NUMBER));
 
-		Assert.assertEquals(2, definition.getOutputMetrics().size());
+		Assert.assertEquals(4, definition.getOutputMetrics().size());
 		Assert.assertTrue(definition.getOutputMetrics().contains(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS.key()));
 		Assert.assertTrue(definition.getOutputMetrics().contains(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES.key()));
 	}
@@ -55,8 +61,31 @@ public class PackageAnalyzerComputerTest {
 
 		Assert.assertEquals("", context.getMeasure(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIERS.key()).getStringValue());
 		Assert.assertEquals(0, context.getMeasure(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES.key()).getIntValue());
+		Assert.assertEquals(0, context.getMeasure(PackageAnalyzerMetrics.PACKAGE_DEGREE.key()).getIntValue());
+		Assert.assertEquals(0, context.getMeasure(PackageAnalyzerMetrics.AVERAGE_DEGREE.key()).getDoubleValue(), 0);
 	}
 
+	@Test
+	public void testOwnDegree() {
+		context.addInputMeasure(PackageAnalyzerMetrics.VERTICE_DEGREE.key(), 7);
+		
+		subject.compute(context);
+		
+		Assert.assertEquals(7, context.getMeasure(PackageAnalyzerMetrics.PACKAGE_DEGREE.key()).getIntValue());
+		Assert.assertEquals(2, context.getMeasure(PackageAnalyzerMetrics.AVERAGE_DEGREE.key()).getDoubleValue(), 0.1);
+	}
+	
+	@Test
+	public void testChildDegree() {
+		//Testing on a project component: AverageDegree = 2 * numEdges / numVertices = 2 * 17 / 3
+		context.addChildrenMeasures(PackageAnalyzerMetrics.PACKAGE_DEGREE.key(), 5, 6, 6);
+		
+		subject.compute(context);
+		
+		Assert.assertEquals(17, context.getMeasure(PackageAnalyzerMetrics.PACKAGE_DEGREE.key()).getIntValue());
+		Assert.assertEquals(4.85, context.getMeasure(PackageAnalyzerMetrics.AVERAGE_DEGREE.key()).getDoubleValue(), 0.1);
+	}
+	
 	@Test
 	public void testOwnIdentifiers() {
 		context.addInputMeasure(PackageAnalyzerMetrics.PACKAGE_DEPENDENCY_CYCLES_IDENTIFIER.key(), "1,2,3");

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerMetricsTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/metrics/PackageAnalyzerMetricsTest.java
@@ -7,7 +7,7 @@ public class PackageAnalyzerMetricsTest {
 
 	@Test
 	public void test() {
-		Assert.assertEquals(3,  new PackageAnalyzerMetrics().getMetrics().size());
+		Assert.assertEquals(6,  new PackageAnalyzerMetrics().getMetrics().size());
 	}
 	
 }

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractPackageAnalyzerRuleTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractPackageAnalyzerRuleTest.java
@@ -15,6 +15,7 @@ import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
 
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Package;
@@ -75,6 +76,11 @@ public class AbstractPackageAnalyzerRuleTest extends BaseRuleTest {
 
 		@Override
 		public void define(NewRepository context) {
+			// Unused
+		}
+		
+		@Override
+		public void defineRemediationTimes(NewRule rule) {
 			// Unused
 		}
 

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRuleTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRuleTest.java
@@ -1,6 +1,7 @@
 package nl.futureedge.sonar.plugin.packageanalyzer.rules;
 
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -70,6 +71,8 @@ public class AbstractnessRuleTest extends BaseRuleTest {
 		final Model<Location> model = createModel();
 		subject.scanModel(sensorContext, activeRule, model);
 
+		for (Iterator<Issue> iter = sensorContext.allIssues().iterator(); iter.hasNext();)
+			System.out.println("ISSUE REPORTED: " + iter.next());
 		// Check one issue on packageA
 		Assert.assertEquals(3, sensorContext.allIssues().size());
 		Map<String, Issue> issues = sensorContext.allIssues().stream().collect(

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRuleTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/AbstractnessRuleTest.java
@@ -1,7 +1,6 @@
 package nl.futureedge.sonar.plugin.packageanalyzer.rules;
 
 import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -70,9 +69,7 @@ public class AbstractnessRuleTest extends BaseRuleTest {
 	public void test() {
 		final Model<Location> model = createModel();
 		subject.scanModel(sensorContext, activeRule, model);
-
-		for (Iterator<Issue> iter = sensorContext.allIssues().iterator(); iter.hasNext();)
-			System.out.println("ISSUE REPORTED: " + iter.next());
+		
 		// Check one issue on packageA
 		Assert.assertEquals(3, sensorContext.allIssues().size());
 		Map<String, Issue> issues = sensorContext.allIssues().stream().collect(

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/DistanceFromMainSequenceRuleTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/DistanceFromMainSequenceRuleTest.java
@@ -1,0 +1,126 @@
+package nl.futureedge.sonar.plugin.packageanalyzer.rules;
+
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.config.MapSettings;
+import org.sonar.api.config.PropertyDefinitions;
+import org.sonar.api.config.Settings;
+import org.sonar.api.rule.RuleKey;
+
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Name;
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
+
+public class DistanceFromMainSequenceRuleTest extends BaseRuleTest {
+	
+	private Settings settings = new MapSettings(new PropertyDefinitions(PackageAnalyzerProperties.definitions()));
+	private DistanceFromMainSequenceRule subject = new DistanceFromMainSequenceRule(settings);
+	private SensorContextTester sensorContext = SensorContextTester.create(Paths.get("./src/main/java"));
+	private ActiveRule activeRule = Mockito.mock(ActiveRule.class);
+
+	@Before
+	public void setup() {
+		Mockito.when(activeRule.param("maximum")).thenReturn("30");
+		Mockito.when(activeRule.ruleKey()).thenReturn(RuleKey.of("testRepo", "testKey"));
+	}
+
+	/**
+	 * <p>
+	 * PackageA -> 2 abstract from 3 classes -> 66% Abstractness
+	 * PackageA -> Uses 2 packages; used by 1 packages -> 2 / 3 -> 66% Instability
+	 * PackageA -> D = |A + I - 1| = 32% -> Issue
+	 * </p>
+	 * <p>
+	 * PackageB -> 1 abstract from 3 classes -> 33% Abstractness
+	 * PackageB -> Uses 2 packages; used by 1 packages -> 2 / 3 -> 66% Instability
+	 * PackageB -> D = |A + I - 1| = 1% -> No Issue
+	 * </p>
+	 * <p>
+	 * PackageC -> 0 abstract from 3 classes -> 0% Abstractness
+	 * PackageC -> Uses 1 package; used by 2 packages -> 1 / 3 -> 33% Instability
+	 * PackageC -> D = |A + I - 1| = 66% -> Issue
+	 * </p>
+	 * <p>
+	 * PackageD -> 1 abstract from 2 classes -> 50% Abstractness
+	 * PackageD -> Uses 1 packages; used by 2 packages -> 1 / 3 -> 33% Instability
+	 * PackageD -> D = |A + I - 1| = 17% -> No Issue
+	 * </p>
+	 */
+	private Model<Location> createModel() {
+		final Model<Location> model = new Model<>();
+		model.addPackage("packageA", location("packageA/package-info.java"));
+		final Class<Location> cAA = model.addClass(Name.of("packageA.ClassA"), true, location("packageA/ClassA.java"));
+		cAA.addUsage(Name.of("packageB.ClassA"));
+		final Class<Location> cAB = model.addClass(Name.of("packageA.ClassB"), false, location("packageA/ClassB.java"));
+		cAB.addUsage(Name.of("packageC.ClassB"));
+		model.addClass(Name.of("packageA.ClassC"), true, location("packageA/ClassC.java"));
+		
+		model.addPackage("packageB", location("packageB/package-info.java"));
+		final Class<Location> cBA = model.addClass(Name.of("packageB.ClassA"), false, location("packageB/ClassA.java"));
+		cBA.addUsage(Name.of("packageD.ClassA"));
+		model.addClass(Name.of("packageB.ClassB"), true, location("packageB/ClassB.java"));
+		final Class<Location> cBC = model.addClass(Name.of("packageB.ClassC"), false, location("packageB/ClassC.java"));
+		cBC.addUsage(Name.of("packageA.ClassC"));
+		
+		model.addPackage("packageC", location("packageC/package-info.java"));
+		model.addClass(Name.of("packageC.ClassA"), false, location("packageC/ClassA.java"));
+		model.addClass(Name.of("packageC.ClassB"), false, location("packageC/ClassB.java"));
+		final Class<Location> cCC = model.addClass(Name.of("packageC.ClassC"), false, location("packageC/ClassC.java"));
+		cCC.addUsage(Name.of("packageD.ClassB"));
+		
+		model.addPackage("packageD", location("packageD/package-info.java"));
+		final Class<Location> cDA = model.addClass(Name.of("packageD.ClassA"), true, location("packageD/ClassA.java"));
+		cDA.addUsage(Name.of("packageC.ClassA"));
+		model.addClass(Name.of("packageD.ClassB"), false, location("packageD/ClassB.java"));
+		
+		return model;
+	}
+	
+	@Test
+	public void test() {
+		final Model<Location> model = createModel();
+
+		subject.scanModel(sensorContext, activeRule, model);
+
+		// Check for two issues on packageA and packageC
+		Assert.assertEquals(2, sensorContext.allIssues().size());
+		
+		// First issue on packageA
+		final Issue issue = sensorContext.allIssues().iterator().next();
+		final String message = issue.primaryLocation().message();
+		System.out.println("Message: " + message);
+		Assert.assertEquals(BaseRuleTest.PROJECT_KEY + ":packageA/package-info.java", 
+				issue.primaryLocation().inputComponent().key());
+		Assert.assertEquals("Distance from main sequence value is too high (32%), consider refactoring the package in order to lower it"
+				+ " (values for instability: 66%, abstractness: 66%).", message);
+	}
+	
+	@Test
+	public void testClasses() {
+		settings.setProperty(PackageAnalyzerProperties.ISSUE_MODE_KEY, PackageAnalyzerProperties.ISSUE_MODE_CLASS);
+		final Model<Location> model = createModel();
+
+		subject.scanModel(sensorContext, activeRule, model);
+
+		// Check three issues on packageA and one on packageC
+		Assert.assertEquals(4, sensorContext.allIssues().size());
+		final Map<String, Issue> issues = sensorContext.allIssues().stream().collect(
+				Collectors.toMap(issue -> issue.primaryLocation().inputComponent().key(), Function.identity()));
+
+		Assert.assertTrue(issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageA/ClassA.java"));
+		Assert.assertTrue(issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageA/ClassB.java"));
+		Assert.assertTrue(issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageA/ClassC.java"));
+		Assert.assertTrue(issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageC/ClassC.java"));
+	}
+}

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/UnstableDependencyRuleTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/rules/UnstableDependencyRuleTest.java
@@ -1,0 +1,113 @@
+package nl.futureedge.sonar.plugin.packageanalyzer.rules;
+
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.config.MapSettings;
+import org.sonar.api.config.PropertyDefinitions;
+import org.sonar.api.config.Settings;
+import org.sonar.api.rule.RuleKey;
+
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Class;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
+import nl.futureedge.sonar.plugin.packageanalyzer.model.Name;
+import nl.futureedge.sonar.plugin.packageanalyzer.settings.PackageAnalyzerProperties;
+
+public class UnstableDependencyRuleTest extends BaseRuleTest {
+	
+	private Settings settings = new MapSettings(new PropertyDefinitions(PackageAnalyzerProperties.definitions()));
+	public UnstableDependencyRule subject = new UnstableDependencyRule(settings);
+	private SensorContextTester sensorContext = SensorContextTester.create(Paths.get("./src/main/java"));
+	private ActiveRule activeRule = Mockito.mock(ActiveRule.class);
+
+	@Before
+	public void setup() {
+		Mockito.when(activeRule.param("maximum")).thenReturn("30");
+		Mockito.when(activeRule.ruleKey()).thenReturn(RuleKey.of("testRepo", "testKey"));
+	}
+	
+	/**
+	 * <p>
+	 * Package A: Instability: 2/5 -> 40%, Unstable dependencies from other packages: 3,
+	 * Unstable Dependency Ratio: 2/5 -> 40% -> Issue
+	 * </p>
+	 * <p>
+	 * Package B: Instability: 1/3 -> 33%, Unstable dependencies from other packages: 1,
+	 * Unstable Dependency Ratio: 2/3 -> 66% -> Issue
+	 * </p>
+	 * <p>
+	 * Package C: Instability: 2/4 -> 50%, Unstable dependencies from other packages: 1,
+	 * Unstable Dependency Ratio: 1/4 -> 25% -> No Issue
+	 * </p>
+	 * <p>
+	 * Package D: Instability: 3/4 -> 75%, Unstable dependencies from other packages: 0,
+	 * Unstable Dependency Ratio: 0/4 -> 0% -> No Issue
+	 * </p>
+	 */
+	private Model<Location> createModel() {
+		final Model<Location> model = new Model<>();
+		model.addPackage("packageA", location("packageA/package-info.java"));
+		final Class<Location> cAA = model.addClass(Name.of("packageA.ClassA"), false, location("packageA/ClassA.java"));
+		final Class<Location> cBA = model.addClass(Name.of("packageA.ClassB"), false, location("packageA/ClassB.java"));
+		cAA.addUsage(Name.of("packageB.ClassA")); //2 efferent packages, 3 afferent packages
+		cBA.addUsage(Name.of("packageC.ClassA"));
+		
+		model.addPackage("packageB", location("packageB/package-info.java"));
+		final Class<Location> cAB = model.addClass(Name.of("packageB.ClassA"), false, location("packageB/ClassA.java"));
+		cAB.addUsage(Name.of("packageA.ClassA")); //1 efferent package, 2 afferent packages
+		
+		model.addPackage("packageC", location("packageC/package-info.java"));
+		final Class<Location> cAC = model.addClass(Name.of("packageC.ClassA"), false, location("packageC/ClassA.java"));
+		cAC.addUsage(Name.of("packageA.ClassA")); //2 efferent packages, 2 afferent packages
+		cAC.addUsage(Name.of("packageD.ClassA"));
+		
+		model.addPackage("packageD", location("packageD/package-info.java"));
+		final Class<Location> cAD = model.addClass(Name.of("packageD.ClassA"), false, location("packageD/ClassA.java"));
+		final Class<Location> cBD = model.addClass(Name.of("packageD.ClassB"), false, location("packageD/ClassB.java"));
+		cAD.addUsage(Name.of("packageA.ClassA")); //3 efferent packages, 1 afferent package
+		cAD.addUsage(Name.of("packageB.ClassA"));
+		cBD.addUsage(Name.of("packageA.ClassB"));
+		cBD.addUsage(Name.of("packageC.ClassA"));
+		return model;
+	}
+	
+	@Test
+	public void test() {
+		final Model<Location> model = createModel();
+		subject.scanModel(sensorContext, activeRule, model);
+		
+		//2 Issues reported on package A and B
+		Assert.assertEquals(2, sensorContext.allIssues().size());
+		final Map<String, Issue> issues = sensorContext.allIssues().stream().collect(
+				Collectors.toMap(issue -> issue.primaryLocation().inputComponent().key(), Function.identity()));
+		Assert.assertTrue("Issue was not reported on package A", issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageA/package-info.java"));
+		Assert.assertTrue("Issue was not reported on package B", issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageB/package-info.java"));
+		
+	}
+	
+	@Test
+	public void testClasses() {
+		settings.setProperty(PackageAnalyzerProperties.ISSUE_MODE_KEY, PackageAnalyzerProperties.ISSUE_MODE_CLASS);
+		final Model<Location> model = createModel();
+		subject.scanModel(sensorContext, activeRule, model);
+		
+		//3 Issues reported - 2 classes on package A, and 1 class on package B
+		Assert.assertEquals(3, sensorContext.allIssues().size());
+		final Map<String, Issue> issues = sensorContext.allIssues().stream().collect(
+				Collectors.toMap(issue -> issue.primaryLocation().inputComponent().key(), Function.identity()));
+		Assert.assertTrue("Issue was not reported on package A class A", issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageA/ClassA.java"));
+		Assert.assertTrue("Issue was not reported on package A class B", issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageA/ClassB.java"));
+		Assert.assertTrue("Issue was not reported on package B class A", issues.containsKey(BaseRuleTest.PROJECT_KEY + ":packageB/ClassA.java"));
+		
+	}
+	
+}

--- a/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/sensor/AbstractSensorTest.java
+++ b/plugin/src/test/java/nl/futureedge/sonar/plugin/packageanalyzer/sensor/AbstractSensorTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
 
 import nl.futureedge.sonar.plugin.packageanalyzer.model.Model;
 import nl.futureedge.sonar.plugin.packageanalyzer.rules.Location;
@@ -65,6 +66,11 @@ public class AbstractSensorTest {
 			// Unused
 		}
 
+		@Override
+		public void defineRemediationTimes(NewRule rule) {
+			// Unused
+		}
+		
 		@Override
 		public void scanModel(SensorContext context, String language, Model<Location> model) {
 			called = true;


### PR DESCRIPTION
Changes: 
- Possibility of reporting in the first package of each cycle (1 issue per cycle, avoiding redundant information) by selecting "package" -> "first" in the plugin settings.
- Added dynamic remediation times varying on the settings selected (based on Sonar's guidelines https://docs.sonarqube.org/display/DEV/Coding+Rule+Guidelines#CodingRuleGuidelines-Evaluationoftheremediationcost)